### PR TITLE
Load env file in memory

### DIFF
--- a/configent.js
+++ b/configent.js
@@ -1,4 +1,4 @@
-const { existsSync, readdirSync } = require('fs')
+const { existsSync, readdirSync, readFileSync } = require('fs')
 const { resolve, dirname } = require('path')
 let instances = {}
 let detectedFromDefaults = {}
@@ -72,8 +72,21 @@ function configent(defaults, input = {}, configentOptions) {
     }
 
     function getEnvConfig() {
-        useDotEnv && require('dotenv').config()
-        const entries = Object.entries(process.env)
+        let env = process.env
+        if (useDotEnv) {
+            try {
+                const envPath = resolve(process.cwd(), '.env')
+                const envContents = readFileSync(envPath, 'utf8')
+                env = {
+                    ...require('dotenv').parse(envContents),
+                    ...env
+                }
+            } catch (e) {
+                // ignore
+            }
+        }
+
+        const entries = Object.entries(env)
             .filter(([key]) => key.match(upperCaseRE))
             .map(parseField)
 


### PR DESCRIPTION
Fixes https://github.com/roxiness/routify/issues/429

Load `.env` file without polluting `process.env`.

Most of the logic is referenced from https://github.com/motdotla/dotenv/blob/f7f7df4ff2de97f39d22de8170e33666bdb69338/lib/main.js#L94-L106 for dotenv v8.6.0

Note: Untested