### PR TITLE
also supports '[name].config.cjs'

### DIFF
--- a/configent.js
+++ b/configent.js
@@ -103,8 +103,16 @@ function configent(defaults, input = {}, configentOptions) {
     }
 
     function getUserConfig() {
-        const path = resolve(process.cwd(), `${name}.config.js`)
-        return existsSync(path) ? require(path) : {}
+        const path_js = resolve(process.cwd(), `${name}.config.js`)
+        const path_cjs = resolve(process.cwd(), `${name}.config.cjs`)
+
+        if (existsSync(path_js)) {
+            return require(path_js);
+        } else if (existsSync(path_cjs)) {
+            return require(path_cjs);
+        } else {
+            return {};
+        }
     }
 
     function getPackageConfig() {


### PR DESCRIPTION
if you have "type" : "module" in your package.json
then you will get error for having **[name].config.js**

but you can have **[name].config.cjs** but _configent_ doesn't require **cjs** file by default.
so, adding code to check and require **[name].config.cjs** if there is no **[name].config.js** file.

btw, no error handling is implemented.